### PR TITLE
GraphQL Task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+end_of_line = lf
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.ts]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 [*]
 end_of_line = lf
+quote_type = single
 
 [*.js]
 indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.ts text eol=lf

--- a/gql.postman_collection.json
+++ b/gql.postman_collection.json
@@ -1,0 +1,435 @@
+{
+	"info": {
+		"_postman_id": "8791fce4-4c40-409c-aa7f-db3244896e0c",
+		"name": "gql",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "14129983"
+	},
+	"item": [
+		{
+			"name": "2.1 Get 4 entities",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query allEntities {\r\n    memberTypes {\r\n        id\r\n        discount\r\n        monthPostsLimit\r\n    }\r\n    posts {\r\n        id\r\n        title\r\n        content\r\n    }\r\n    users {\r\n        id\r\n        email\r\n        firstName\r\n        lastName\r\n        subscribedToUserIds\r\n    }\r\n    profiles {\r\n        id\r\n        avatar\r\n        birthday\r\n        sex\r\n        country\r\n        city\r\n        street\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.2 Get 4 entities by id",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query entitiesByIds ($userId: UUID!, $profileId: UUID!, $memberTypeId: String!, $postId: UUID!) {\r\n    user(id: $userId) {\r\n        id\r\n        firstName\r\n        lastName\r\n        email\r\n    }\r\n    profile(id: $profileId) {\r\n        id\r\n        avatar\r\n        birthday\r\n        sex\r\n        country\r\n        city\r\n        street\r\n    }\r\n    memberType(id: $memberTypeId) {\r\n        id\r\n        discount\r\n        monthPostsLimit\r\n    }\r\n    post(id: $postId) {\r\n        id\r\n        title\r\n        content\r\n    }\r\n}",
+						"variables": "{\r\n    \"userId\": \"17be2e71-eef4-4a0d-87bf-6e3592cc4471\",\r\n    \"profileId\": \"4d1a321d-143b-464a-b749-4f5e577a50ad\",\r\n    \"memberTypeId\": \"basic\",\r\n    \"postId\": \"e21d9622-efb6-4e09-a0a1-bd330e30031f\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.3 Get users with profile and post",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query allUsers {\r\n    users {\r\n        id\r\n        firstName\r\n        lastName\r\n        email\r\n        profile {\r\n            id\r\n            avatar\r\n            birthday\r\n            sex\r\n            country\r\n            city\r\n            street\r\n            memberType {\r\n                id\r\n                discount\r\n                monthPostsLimit\r\n            }\r\n        }\r\n        posts {\r\n            id\r\n            title\r\n            content\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.4 Get user by id with profile and posts",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query userById ($userId: UUID!) {\r\n    user(id: $userId) {\r\n        id\r\n        firstName\r\n        lastName\r\n        email\r\n        profile {\r\n            id\r\n            avatar\r\n            birthday\r\n            sex\r\n            country\r\n            city\r\n            street\r\n            memberType {\r\n                id\r\n                discount\r\n                monthPostsLimit\r\n            }\r\n        }\r\n        posts {\r\n            id\r\n            title\r\n            content\r\n        }\r\n\r\n    }\r\n}",
+						"variables": "{\r\n    \"userId\": \"2f305e81-c7d4-4e7a-a23e-7f1a5d2514a0\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.5 Get users with subscriptions",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query usersWithSubscriptions {\r\n    users {\r\n        id\r\n        firstName\r\n        lastName\r\n        profile {\r\n            id\r\n            avatar\r\n            birthday\r\n            sex\r\n            country\r\n            city\r\n            street\r\n        }\r\n        userSubscribedTo {\r\n            id\r\n            firstName\r\n            lastName\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.6 Get user by id with followers and posts",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query userByIdWithFollowersAndPosts ($userId: UUID!) {\r\n    user(id: $userId) {\r\n        id\r\n        firstName\r\n        lastName\r\n        subscribedToUser {\r\n            id\r\n            firstName\r\n            lastName\r\n        }\r\n        posts {\r\n            id\r\n            title\r\n            content\r\n        }\r\n    }\r\n}",
+						"variables": "{\r\n    \"userId\": \"2f305e81-c7d4-4e7a-a23e-7f1a5d2514a0\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.7 Get users with subscriptions and followers",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query usersWithSubscriptionsAndFollowers {\r\n    users {\r\n        id\r\n        firstName\r\n        userSubscribedTo {\r\n            id\r\n            firstName\r\n            userSubscribedTo {\r\n                id\r\n                firstName\r\n            }\r\n            subscribedToUser {\r\n                id\r\n                firstName\r\n            }\r\n        }\r\n        subscribedToUser {\r\n            id\r\n            firstName\r\n            userSubscribedTo {\r\n                id\r\n                firstName\r\n            }\r\n            subscribedToUser {\r\n                id\r\n                firstName\r\n            }\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.8 Create user",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation createUser($createUserDTO: CreateUserDTO!) {\r\n    createUser(createUserDTO: $createUserDTO) {\r\n        id\r\n        firstName\r\n        lastName,\r\n        email\r\n    }\r\n}",
+						"variables": "{\r\n    \"createUserDTO\": {\r\n        \"firstName\": \"2\",\r\n        \"lastName\": \"1\",\r\n        \"email\": \"mail\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.9 Create profile",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation createProfile($createProfileDTO: CreateProfileDTO!) {\r\n    createProfile(createProfileDTO: $createProfileDTO) {\r\n        id\r\n        avatar\r\n        birthday\r\n        sex\r\n        country\r\n        city\r\n        street\r\n    }\r\n}",
+						"variables": "{\r\n    \"createProfileDTO\": {\r\n        \"city\": \"City\",\r\n        \"avatar\": \"avatar\",\r\n        \"street\": \"street\",\r\n        \"sex\": \"no\",\r\n        \"country\": \"ru\",\r\n        \"birthday\": 100,\r\n        \"memberTypeId\": \"basic\",\r\n        \"userId\": \"994b2d51-741c-4517-9d42-e8c067d70ed4\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.10 Create post",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation createPost($createPostDTO: CreatePostDTO!) {\r\n    createPost(createPostDTO: $createPostDTO) {\r\n        id\r\n        title\r\n        content\r\n    }\r\n}",
+						"variables": "{\r\n    \"createPostDTO\": {\r\n        \"title\": \"1\",\r\n        \"content\": \"2\",\r\n        \"userId\": \"994b2d51-741c-4517-9d42-e8c067d70ed4\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.12 Update user",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation updateUser($userId: UUID!, $updateUserDTO: UpdateUserDTO!) {\r\n    updateUser(\r\n        id: $userId,\r\n        updateUserDTO: $updateUserDTO\r\n        )\r\n    {\r\n        id\r\n        firstName\r\n        lastName\r\n        email\r\n    }\r\n}",
+						"variables": "{\r\n    \"userId\": \"994b2d51-741c-4517-9d42-e8c067d70ed4\",\r\n    \"updateUserDTO\": {\r\n        \"firstName\": \"upd\",\r\n        \"lastName\": \"upd\",\r\n        \"email\": \"email@mail.com\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.13 Update profile",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation updateProfile($profileID: UUID!, $updateProfileDTO: UpdateProfileDTO!) {\r\n    updateProfile(\r\n        id: $profileID,\r\n        updateProfileDTO: $updateProfileDTO\r\n        )\r\n    {\r\n        id\r\n        avatar\r\n        birthday\r\n        sex\r\n        country\r\n        city\r\n        street\r\n    }\r\n}",
+						"variables": "{\r\n    \"profileID\": \"5cd302e2-c525-4142-9bc8-da0412480998\",\r\n    \"updateProfileDTO\": {\r\n        \"avatar\": \"no avatar\",\r\n        \"birthday\": 10000,\r\n        \"sex\": \"male\",\r\n        \"country\": \"nz\",\r\n        \"city\": \"updated\",\r\n        \"street\": \"street\",\r\n        \"memberTypeId\": \"business\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.14 Update post",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation updatePost($postId: UUID!, $updatePostDTO: UpdatePostDTO!) {\r\n    updatePost(\r\n        id: $postId,\r\n        updatePostDTO: $updatePostDTO\r\n        )\r\n    {\r\n        id\r\n        title\r\n        content\r\n    }\r\n}",
+						"variables": "{\r\n    \"postId\": \"14e280c7-ecf0-4ba1-ac38-7a8ce97d53e6\",\r\n    \"updatePostDTO\": {\r\n        \"title\": \"updated\",\r\n        \"content\": \"updated\"\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.15 Update memberType",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation updateMemberType($memberTypeId: String!, $updateMemberTypeDTO: UpdateMemberTypeDTO!) {\r\n    updateMemberType(\r\n        id: $memberTypeId,\r\n        updateMemberTypeDTO: $updateMemberTypeDTO\r\n        )\r\n    {\r\n        id\r\n        discount\r\n        monthPostsLimit\r\n    }\r\n}",
+						"variables": "{\r\n    \"memberTypeId\": \"basic\",\r\n    \"updateMemberTypeDTO\": {\r\n        \"discount\": 10,\r\n        \"monthPostsLimit\": 0\r\n    }\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.16a Subscribe to user",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation subscribeToUser($userId: UUID!, $subscriberId: UUID!) {\r\n    subscribeTo(\r\n        userId: $userId,\r\n        subscriberId: $subscriberId\r\n        )\r\n    {\r\n        id\r\n        firstName\r\n        lastName\r\n        subscribedToUser {\r\n            id\r\n            firstName\r\n            lastName\r\n        }\r\n    }\r\n}",
+						"variables": "{\r\n    \"userId\": \"74d17e71-dedc-4343-a9c8-88c11e928252\",\r\n    \"subscriberId\": \"74d17e71-dedc-4343-a9c8-88c11e928252\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.16b Unsubscribe from user",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation unsubscribeFromUser($userId: UUID!, $unsubId: UUID!) {\r\n    unsubscribeFrom(\r\n        userId: $userId,\r\n        unsubId: $unsubId\r\n        )\r\n    {\r\n        id\r\n        firstName\r\n        lastName\r\n        subscribedToUser {\r\n            id\r\n            firstName\r\n            lastName\r\n        }\r\n    }\r\n}",
+						"variables": "{\r\n    \"userId\": \"a7ec52dd-126c-40bf-a50d-05b30fea7d58\",\r\n    \"unsubId\": \"8b668218-9a50-4e02-9163-78c452c23ca4\"\r\n}"
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "4 Query with exceeding depth",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query nestedPosts {\r\n    posts {\r\n        id\r\n        author {\r\n            id\r\n            posts {\r\n                author {\r\n                    id\r\n                    posts {\r\n                        id\r\n                        author {\r\n                            id\r\n                            posts {\r\n                                id\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n            }\r\n        }\r\n    }\r\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/graphql",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/plugins/seed.ts
+++ b/src/plugins/seed.ts
@@ -67,7 +67,6 @@ export async function seed(db: DB) {
   for (let i = 0; i < subscriptions; i++) {
     while (true) {
       const idsPair = getPair(userIds);
-      console.log(idsPair);
 
       let [user, subscriber] = await db.users.findMany({
         key: "id",

--- a/src/plugins/seed.ts
+++ b/src/plugins/seed.ts
@@ -5,9 +5,9 @@ import { ProfileEntity } from "../utils/DB/entities/DBProfiles";
 import { UserEntity } from "../utils/DB/entities/DBUsers";
 
 const config = {
-  users: 10,
-  maxPostsPerUser: 6,
-  subscriptions: 30,
+  users: 10, // Number of users with profiles to create
+  maxPostsPerUser: 6, // Max number of posts for each user (random value from 1 to this limit)
+  subscriptions: 30, // Total number of random subscriptions
 };
 
 export default fp(async (fastify): Promise<void> => {

--- a/src/plugins/seed.ts
+++ b/src/plugins/seed.ts
@@ -1,0 +1,70 @@
+import fp from "fastify-plugin";
+import DB from "../utils/DB/DB";
+import { PostEntity } from "../utils/DB/entities/DBPosts";
+import { ProfileEntity } from "../utils/DB/entities/DBProfiles";
+import { UserEntity } from "../utils/DB/entities/DBUsers";
+
+export default fp(async (fastify): Promise<void> => {
+  const { db } = fastify;
+  seed(db);
+});
+
+function getRandomItem<T>(arr: T[]): T {
+  const { length } = arr;
+  const index = Math.round(Math.random() * (length - 1));
+  return arr[index];
+}
+
+function getPair<T>(arr: T[]): [T, T] {
+  let pair: [T, T] = [getRandomItem(arr), getRandomItem(arr)];
+  while (pair[0] === pair[1]) {
+    pair = getPair(arr);
+  }
+  return pair;
+}
+
+export async function seed(db: DB) {
+  const userIds: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const userDTO: Omit<UserEntity, "id" | "subscribedToUserIds"> = {
+      firstName: `User ${i}`,
+      lastName: `Last ${i}`,
+      email: `user${i}@mail.com`,
+    };
+    const user = await db.users.create(userDTO);
+    userIds.push(user.id);
+
+    const profileDTO: Omit<ProfileEntity, "id"> = {
+      avatar: `avatar ${i}`,
+      sex: getRandomItem(["male", "female"]),
+      birthday: Number(new Date()),
+      country: getRandomItem(["us", "uk", "ca", "cn", "ru"]),
+      street: "Street",
+      city: "City",
+      memberTypeId: getRandomItem(["basic", "business"]),
+      userId: user.id,
+    };
+    await db.profiles.create(profileDTO);
+
+    for (let j = 0; j < 1 + Math.random() * 6; j++) {
+      const postDTO: Omit<PostEntity, "id"> = {
+        title: `post #${i * 10 + j}`,
+        content: "lorem ipsum dolor est",
+        userId: user.id,
+      };
+      await db.posts.create(postDTO);
+    }
+  }
+
+  for (let i = 1; i < 30; i++) {
+    const idsPair = getPair(userIds);
+
+    const [user, subscriber] = await db.users.findMany({
+      key: "id",
+      equalsAnyOf: idsPair,
+    });
+    await db.users.change(user.id, {
+      subscribedToUserIds: [...user.subscribedToUserIds, subscriber.id],
+    });
+  }
+}

--- a/src/routes/graphql/errors.ts
+++ b/src/routes/graphql/errors.ts
@@ -1,0 +1,17 @@
+export const enum Entities {
+  MEMBER_TYPE = "Member type",
+  USER = "User",
+  POST = "Post",
+  PROFILE = "Profile",
+}
+
+export const enum Errors {
+  HAS_PROFILE = "User already has a profile",
+  SELF_SUBSCRIBE = "User can't be subscribed to himself",
+  ALREADY_SUBSCRIBED = "Already subscribed",
+  NO_SUBSCRIPTION = "No active subscription",
+}
+
+export function entityNotFoundMessage(entity: Entities, id: string): string {
+  return `${entity} with id ${id} not found`;
+}

--- a/src/routes/graphql/filterDTO.ts
+++ b/src/routes/graphql/filterDTO.ts
@@ -1,0 +1,11 @@
+export function filterDTO<T extends Record<string, unknown>>(
+  dto: T
+): Partial<T> {
+  const entries = Object.entries(dto);
+  for (const [key, value] of entries) {
+    if (value === null) {
+      delete dto[key];
+    }
+  }
+  return dto;
+}

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,18 +1,214 @@
-import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { graphqlBodySchema } from './schema';
+import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
+import { graphql } from "graphql";
+import {
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLFloat,
+  GraphQLString,
+  GraphQLSchema,
+  GraphQLList,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+} from "graphql/type";
+import DB from "../../utils/DB/DB";
+import { graphqlBodySchema } from "./schema";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
   fastify.post(
-    '/',
+    "/",
     {
       schema: {
         body: graphqlBodySchema,
       },
     },
-    async function (request, reply) {}
+    async function (request, reply) {
+      if (request.body.query) {
+        console.log(request.body.query);
+        return graphql({
+          schema,
+          source: request.body.query,
+          contextValue: this.db,
+        });
+      }
+      if (request.body.mutation)
+        return graphql({ schema, source: request.body.mutation });
+    }
   );
 };
 
 export default plugin;
+
+const memberType: GraphQLObjectType = new GraphQLObjectType({
+  name: "MemberType",
+  fields: () => ({
+    id: { type: GraphQLString },
+    discount: { type: new GraphQLNonNull(GraphQLFloat) },
+    monthPostLimit: { type: new GraphQLNonNull(GraphQLInt) },
+  }),
+});
+
+const postType: GraphQLObjectType = new GraphQLObjectType({
+  name: "Post",
+  fields: () => ({
+    id: { type: GraphQLString },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type: new GraphQLNonNull(GraphQLString) },
+    author: {
+      type: new GraphQLNonNull(userType),
+      resolve: (obj, args, ctx: DB) => {
+        return ctx.users.findOne({ key: "id", equals: obj.userId });
+      },
+    },
+  }),
+});
+
+const createPostType: GraphQLInputObjectType = new GraphQLInputObjectType({
+  name: "CreatePostDTO",
+  fields: () => ({
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+
+const userType: GraphQLObjectType = new GraphQLObjectType({
+  name: "User",
+  fields: () => ({
+    id: { type: GraphQLString },
+    firstName: { type: new GraphQLNonNull(GraphQLString) },
+    lastName: { type: new GraphQLNonNull(GraphQLString) },
+    email: { type: new GraphQLNonNull(GraphQLString) },
+    profile: { type: profileType },
+    memberType: { type: memberType },
+    posts: {
+      type: new GraphQLList(postType),
+      resolve: (obj, args, ctx: DB) => {
+        return ctx.posts.findMany({ key: "userId", equals: obj.id });
+      },
+    },
+    subscribedTo: { type: new GraphQLList(userType) },
+    subscribedToUser: { type: new GraphQLList(userType) },
+  }),
+});
+
+const createUserType: GraphQLInputObjectType = new GraphQLInputObjectType({
+  name: "CreateUserDTO",
+  fields: () => ({
+    firstName: { type: new GraphQLNonNull(GraphQLString) },
+    lastName: { type: new GraphQLNonNull(GraphQLString) },
+    email: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+
+const profileType: GraphQLObjectType = new GraphQLObjectType({
+  name: "Profile",
+  fields: () => ({
+    id: { type: GraphQLString },
+    avatar: { type: new GraphQLNonNull(GraphQLString) },
+    sex: { type: new GraphQLNonNull(GraphQLString) },
+    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    street: { type: new GraphQLNonNull(GraphQLString) },
+    city: { type: new GraphQLNonNull(GraphQLString) },
+    user: { type: new GraphQLNonNull(userType) },
+    memberType: { type: new GraphQLNonNull(memberType) },
+  }),
+});
+
+const createProfileType: GraphQLInputObjectType = new GraphQLInputObjectType({
+  name: "CreateProfileDTO",
+  fields: () => ({
+    avatar: { type: new GraphQLNonNull(GraphQLString) },
+    sex: { type: new GraphQLNonNull(GraphQLString) },
+    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    street: { type: new GraphQLNonNull(GraphQLString) },
+    city: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    memberTypeId: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+
+export const RootQuery = new GraphQLObjectType({
+  name: "RootQueryType",
+  fields: {
+    memberTypes: {
+      type: new GraphQLList(memberType),
+      resolve: (obj, args, ctx: DB) => {
+        return ctx.memberTypes.findMany();
+      },
+    },
+    users: {
+      type: new GraphQLList(userType),
+      resolve: (obj, args, ctx: DB) => {
+        return ctx.users.findMany();
+      },
+    },
+    posts: {
+      type: new GraphQLList(postType),
+      resolve: (obj, args, ctx: DB) => {
+        return ctx.posts.findMany();
+      },
+    },
+    profiles: {
+      type: new GraphQLList(profileType),
+      resolve: (obj, args, ctx: DB) => {
+        return ctx.profiles.findMany();
+      },
+    },
+  },
+});
+
+const Mutations = new GraphQLObjectType({
+  name: "Mutations",
+  fields: {
+    createUser: {
+      type: userType,
+      args: {
+        createUserDTO: { type: createUserType },
+      },
+      async resolve(obj, args, ctx: DB) {
+        return ctx.users.create(args.createUserDTO);
+      },
+    },
+    createProfile: {
+      type: profileType,
+      args: {
+        createProfileDTO: { type: createProfileType },
+      },
+      async resolve(obj, args, ctx: DB) {
+        return ctx.profiles.create(args.createProfileDTO);
+      },
+    },
+    createPost: {
+      type: postType,
+      args: {
+        createPostDTO: { type: createPostType },
+      },
+      async resolve(obj, args, ctx: DB) {
+        return ctx.posts.create(args.createPostDTO);
+      },
+    },
+    deleteUser: {
+      type: userType,
+      args: {},
+      async resolve(args) {
+        return "";
+      },
+    },
+    deleteProfile: {
+      type: userType,
+      args: {},
+      async resolve(args) {
+        return "";
+      },
+    },
+  },
+});
+
+export const schema = new GraphQLSchema({
+  query: RootQuery,
+  mutation: Mutations,
+});

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -118,10 +118,7 @@ const userType: GraphQLObjectType = new GraphQLObjectType({
     profile: {
       type: profileType,
       resolve: (user: UserEntity, args, ctx: Context) => {
-        return ctx.fastify.db.profiles.findOne({
-          key: "userId",
-          equals: user.id,
-        });
+        return ctx.profileByUserIdLoader.load(user.id);
       },
     },
     posts: {
@@ -186,10 +183,6 @@ const profileType: GraphQLObjectType = new GraphQLObjectType({
     memberType: {
       type: new GraphQLNonNull(memberType),
       resolve: async (profile: ProfileEntity, args, ctx: Context) => {
-        // return ctx.fastify.db.memberTypes.findOne({
-        //   key: "id",
-        //   equals: profile.memberTypeId,
-        // });
         return ctx.memberTypeLoader.load(profile.memberTypeId);
       },
     },
@@ -239,10 +232,6 @@ export const RootQuery = new GraphQLObjectType({
         id: { type: GraphQLString },
       },
       resolve: (obj, args, ctx: Context) => {
-        // return ctx.fastify.db.memberTypes.findOne({
-        //   key: "id",
-        //   equals: args.id,
-        // });
         return ctx.memberTypeLoader.load(args.id);
       },
     },
@@ -258,7 +247,6 @@ export const RootQuery = new GraphQLObjectType({
         id: { type: GraphQLUUID },
       },
       resolve: (obj, args, ctx: Context) => {
-        // return ctx.fastify.db.users.findOne({ key: "id", equals: args.id });
         return ctx.userLoader.load(args.id);
       },
     },
@@ -274,7 +262,6 @@ export const RootQuery = new GraphQLObjectType({
         id: { type: GraphQLUUID },
       },
       resolve: (obj, args, ctx: Context) => {
-        // return ctx.fastify.db.posts.findOne({ key: "id", equals: args.id });
         return ctx.postLoader.load(args.id);
       },
     },
@@ -290,7 +277,6 @@ export const RootQuery = new GraphQLObjectType({
         id: { type: GraphQLUUID },
       },
       resolve: (obj, args, ctx: Context) => {
-        // return ctx.fastify.db.profiles.findOne({ key: "id", equals: args.id });
         return ctx.profileLoader.load(args.id);
       },
     },
@@ -378,14 +364,6 @@ const Mutations = new GraphQLObjectType({
       },
       resolve: async (_, args, ctx: Context) => {
         const { userId, subscriberId } = args;
-        // const subscriber = await ctx.fastify.db.users.findOne({
-        //   key: "id",
-        //   equals: subscriberId,
-        // });
-        // const user = await ctx.fastify.db.users.findOne({
-        //   key: "id",
-        //   equals: userId,
-        // });
         const [user, subscriber] = (await ctx.userLoader.loadMany([
           userId,
           subscriberId,
@@ -414,15 +392,6 @@ const Mutations = new GraphQLObjectType({
       },
       resolve: async (_, args, ctx: Context) => {
         const { userId, unsubId } = args;
-        // const unsub = await ctx.fastify.db.users.findOne({
-        //   key: "id",
-        //   equals: unsubId,
-        // });
-        // const user = await ctx.fastify.db.users.findOne({
-        //   key: "id",
-        //   equals: userId,
-        // });
-        throw ctx.fastify.httpErrors.badRequest();
         const [user, unsub] = (await ctx.userLoader.loadMany([
           userId,
           unsubId,

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
-import { graphql } from "graphql";
+import { graphql, parse, validate } from "graphql";
+import depthLimit = require("graphql-depth-limit");
 import {
   GraphQLInt,
   GraphQLObjectType,
@@ -28,7 +29,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     },
     async function (request, reply) {
       if (request.body.query) {
-        console.log(request.body.query);
+        const validationResult = validate(schema, parse(request.body.query), [
+          depthLimit(5),
+        ]);
+        if (validationResult.length) return validationResult[1];
         return graphql({
           schema,
           source: request.body.query,

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -27,7 +27,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request) {
-      const { query, mutation } = request.body;
+      const { query, mutation, variables } = request.body;
       const source: string | null = query || mutation || null;
 
       if (!source) throw this.httpErrors.badRequest();
@@ -36,14 +36,17 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
 
       if (validationResult.length) throw validationResult;
 
+      const { db } = fastify;
+
       const contextValue: Context = {
-        fastify,
+        db,
         ...getLoaders(fastify.db),
       };
 
       return graphql({
         schema,
         source,
+        variableValues: variables,
         contextValue,
       });
     }

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -16,7 +16,7 @@ import {
 } from "./types/profile";
 import { UserType, CreateUserType, UpdateUserType } from "./types/user";
 
-const DEPTH_LIMIT = 5;
+const DEPTH_LIMIT = 6;
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify

--- a/src/routes/graphql/loaders.ts
+++ b/src/routes/graphql/loaders.ts
@@ -1,0 +1,42 @@
+import DataLoader = require("dataloader");
+import DB from "../../utils/DB/DB";
+import { MemberTypeEntity } from "../../utils/DB/entities/DBMemberTypes";
+import { PostEntity } from "../../utils/DB/entities/DBPosts";
+import { ProfileEntity } from "../../utils/DB/entities/DBProfiles";
+import { UserEntity } from "../../utils/DB/entities/DBUsers";
+
+export function getLoaders(db: DB) {
+  const memberTypeLoader = new DataLoader<string, MemberTypeEntity | null>(
+    async (keys: Readonly<string[]>) =>
+      db.memberTypes.findMany({
+        key: "id",
+        equalsAnyOf: [...keys],
+      })
+  );
+
+  const postLoader = new DataLoader<string, PostEntity | null>(
+    async (keys: Readonly<string[]>) =>
+      db.posts.findMany({
+        key: "id",
+        equalsAnyOf: [...keys],
+      })
+  );
+
+  const userLoader = new DataLoader<string, UserEntity | null>(
+    async (keys: Readonly<string[]>) =>
+      db.users.findMany({
+        key: "id",
+        equalsAnyOf: [...keys],
+      })
+  );
+
+  const profileLoader = new DataLoader<string, ProfileEntity | null>(
+    async (keys: Readonly<string[]>) =>
+      db.profiles.findMany({
+        key: "id",
+        equalsAnyOf: [...keys],
+      })
+  );
+
+  return { memberTypeLoader, postLoader, userLoader, profileLoader };
+}

--- a/src/routes/graphql/loaders.ts
+++ b/src/routes/graphql/loaders.ts
@@ -20,7 +20,7 @@ function createLoader<
       return acc;
     }, new Map<string, T>());
 
-    return keys.map((key) => resultsMap.get(key) ?? new Error("Not found"));
+    return keys.map((key) => resultsMap.get(key) ?? null);
   };
 
   return new DataLoader(batchFn);

--- a/src/routes/graphql/loaders.ts
+++ b/src/routes/graphql/loaders.ts
@@ -23,7 +23,10 @@ function createLoader<
 }
 function createPostsByAuthorIdLoader(postsDB: DBPosts) {
   return new DataLoader(async (authorIds: Readonly<string[]>) => {
-    const allPosts = await postsDB.findMany();
+    const allPosts = await postsDB.findMany({
+      key: "userId",
+      equalsAnyOf: authorIds,
+    } as any);
     return authorIds.map((authorId) =>
       allPosts.filter((post) => post.userId === authorId)
     );
@@ -32,7 +35,10 @@ function createPostsByAuthorIdLoader(postsDB: DBPosts) {
 
 function createSubscriptionsByUserIdLoader(usersDB: DBUsers) {
   return new DataLoader(async (userIds: Readonly<string[]>) => {
-    const allUsers = await usersDB.findMany();
+    const allUsers = await usersDB.findMany({
+      key: "subscribedToUserIds",
+      inArrayAnyOf: userIds,
+    } as any);
     return userIds.map((userId) =>
       allUsers.filter((user) => user.subscribedToUserIds.includes(userId))
     );

--- a/src/routes/graphql/loaders.ts
+++ b/src/routes/graphql/loaders.ts
@@ -6,15 +6,34 @@ import { PostEntity } from "../../utils/DB/entities/DBPosts";
 import { ProfileEntity } from "../../utils/DB/entities/DBProfiles";
 import { UserEntity } from "../../utils/DB/entities/DBUsers";
 
+function createLoader<
+  T extends MemberTypeEntity | UserEntity | ProfileEntity | PostEntity
+>(db: DBEntity<T, unknown, unknown>, key: keyof T) {
+  const batchFn = async (keys: Readonly<string[]>) => {
+    const results = await db.findMany({
+      key,
+      equalsAnyOf: [...keys],
+    } as any);
+
+    const resultsMap = results.reduce((acc, item: T) => {
+      acc.set(item.id, item);
+      return acc;
+    }, new Map<string, T>());
+
+    return keys.map((key) => resultsMap.get(key) ?? new Error("Not found"));
+  };
+
+  return new DataLoader(batchFn);
+}
+
 export function getLoaders(db: DB) {
-  const memberTypeLoader = createLoader<MemberTypeEntity>(db.memberTypes, "id");
-  const postLoader = createLoader<PostEntity>(db.posts, "id");
-  const userLoader = createLoader<UserEntity>(db.users, "id");
-  const profileLoader = createLoader<ProfileEntity>(db.profiles, "id");
-  const profileByUserIdLoader = createLoader<ProfileEntity>(
-    db.profiles,
-    "userId"
-  );
+  const { memberTypes, posts, profiles, users } = db;
+
+  const memberTypeLoader = createLoader<MemberTypeEntity>(memberTypes, "id");
+  const postLoader = createLoader<PostEntity>(posts, "id");
+  const userLoader = createLoader<UserEntity>(users, "id");
+  const profileLoader = createLoader<ProfileEntity>(profiles, "id");
+  const profileByUserIdLoader = createLoader<ProfileEntity>(profiles, "userId");
 
   return {
     memberTypeLoader,
@@ -23,22 +42,4 @@ export function getLoaders(db: DB) {
     profileLoader,
     profileByUserIdLoader,
   };
-}
-
-export function createLoader<
-  T extends MemberTypeEntity | UserEntity | ProfileEntity | PostEntity
->(db: DBEntity<T, unknown, unknown>, key: keyof T) {
-  const batchFn = async (keys: Readonly<string[]>) => {
-    const results = await db.findMany({
-      key,
-      equalsAnyOf: [...keys],
-    } as any);
-    const resultsMap = results.reduce((acc, item: T) => {
-      acc.set(item.id, item);
-      return acc;
-    }, new Map<string, T>());
-    return keys.map((key) => resultsMap.get(key) ?? null);
-  };
-
-  return new DataLoader(batchFn);
 }

--- a/src/routes/graphql/mutation.ts
+++ b/src/routes/graphql/mutation.ts
@@ -1,4 +1,5 @@
 import { GraphQLObjectType, GraphQLNonNull, GraphQLString } from "graphql";
+import { Entities, entityNotFoundMessage, Errors } from "./errors";
 import { Context } from "./types/context";
 import { MemberType, UpdateMemberType } from "./types/memberType";
 import { PostType, CreatePostType, UpdatePostType } from "./types/post";
@@ -28,14 +29,24 @@ export const Mutations = new GraphQLObjectType({
         createProfileDTO: { type: CreateProfileType },
       },
       async resolve(_, args, ctx: Context) {
-        const user = await ctx.userLoader.load(args.createProfileDTO.userId);
+        const { userId, memberTypeId } = args.createProfileDTO;
+
+        const user = await ctx.userLoader.load(userId);
         if (!user)
-          throw new Error("Bad request, user with this id does not exist");
+          throw new Error(entityNotFoundMessage(Entities.USER, userId));
+
+        const profile = await ctx.profileByUserIdLoader.load(
+          args.createProfileDTO.userId
+        );
+        if (profile) throw new Error(Errors.HAS_PROFILE);
 
         const memberType = await ctx.memberTypeLoader.load(
           args.createProfileDTO.memberTypeId
         );
-        if (!memberType) throw new Error("Bad request, invalid member type");
+        if (!memberType)
+          throw new Error(
+            entityNotFoundMessage(Entities.MEMBER_TYPE, memberTypeId)
+          );
 
         return ctx.db.profiles.create(args.createProfileDTO);
       },
@@ -46,9 +57,10 @@ export const Mutations = new GraphQLObjectType({
         createPostDTO: { type: CreatePostType },
       },
       async resolve(_, args, ctx: Context) {
-        const user = await ctx.userLoader.load(args.createPostDTO.userId);
+        const { userId } = args.createPostDTO;
+        const user = await ctx.userLoader.load(userId);
         if (!user)
-          throw new Error("Bad request, user with this id does not exist");
+          throw new Error(entityNotFoundMessage(Entities.USER, userId));
 
         return ctx.db.posts.create(args.createPostDTO);
       },
@@ -60,13 +72,15 @@ export const Mutations = new GraphQLObjectType({
         updateMemberTypeDTO: { type: UpdateMemberType },
       },
       async resolve(_, args, ctx: Context) {
-        const updated = await ctx.db.memberTypes.change(
-          args.id,
-          args.updateMemberTypeDTO
-        );
-        if (!updated) throw new Error("Bad request");
-
-        return updated;
+        try {
+          const updated = await ctx.db.memberTypes.change(
+            args.id,
+            args.updateMemberTypeDTO
+          );
+          return updated;
+        } catch {
+          throw new Error(entityNotFoundMessage(Entities.MEMBER_TYPE, args.id));
+        }
       },
     },
     updatePost: {
@@ -76,10 +90,11 @@ export const Mutations = new GraphQLObjectType({
         updatePostDTO: { type: UpdatePostType },
       },
       async resolve(_, args, ctx: Context) {
-        const updated = await ctx.db.posts.change(args.id, args.updatePostDTO);
-        if (!updated) throw new Error("Bad request");
-
-        return updated;
+        try {
+          return await ctx.db.posts.change(args.id, args.updatePostDTO);
+        } catch {
+          throw new Error(entityNotFoundMessage(Entities.POST, args.id));
+        }
       },
     },
     updateProfile: {
@@ -89,13 +104,21 @@ export const Mutations = new GraphQLObjectType({
         updateProfileDTO: { type: UpdateProfileType },
       },
       async resolve(_, args, ctx: Context) {
-        const updated = await ctx.db.profiles.change(
-          args.id,
-          args.updateProfileDTO
-        );
-        if (!updated) throw new Error("Bad request");
+        const { memberTypeId } = args.updateProfileDTO;
+        if (memberTypeId) {
+          const newMemberType = await ctx.memberTypeLoader.load(memberTypeId);
 
-        return updated;
+          if (!newMemberType)
+            throw new Error(
+              entityNotFoundMessage(Entities.MEMBER_TYPE, memberTypeId)
+            );
+        }
+
+        try {
+          return await ctx.db.profiles.change(args.id, args.updateProfileDTO);
+        } catch {
+          throw new Error(entityNotFoundMessage(Entities.PROFILE, args.id));
+        }
       },
     },
     updateUser: {
@@ -105,10 +128,11 @@ export const Mutations = new GraphQLObjectType({
         updateUserDTO: { type: UpdateUserType },
       },
       async resolve(_, args, ctx: Context) {
-        const updated = await ctx.db.users.change(args.id, args.updateUserDTO);
-        if (!updated) throw new Error("Bad request");
-
-        return updated;
+        try {
+          return await ctx.db.users.change(args.id, args.updateUserDTO);
+        } catch {
+          throw new Error(entityNotFoundMessage(Entities.USER, args.id));
+        }
       },
     },
     subscribeTo: {
@@ -119,21 +143,22 @@ export const Mutations = new GraphQLObjectType({
       },
       resolve: async (_, args, ctx: Context) => {
         const { userId, subscriberId } = args;
+        if (userId === subscriberId) throw new Error(Errors.SELF_SUBSCRIBE);
+
         const user = await ctx.userLoader.load(userId);
+        if (!user)
+          throw new Error(entityNotFoundMessage(Entities.USER, userId));
+
         const subscriber = await ctx.userLoader.load(subscriberId);
-        if (
-          user &&
-          subscriber &&
-          !user.subscribedToUserIds.includes(subscriberId)
-        ) {
-          const subscribedToUserIds = [
-            ...user.subscribedToUserIds,
-            subscriberId,
-          ];
-          return await ctx.db.users.change(userId, {
-            subscribedToUserIds,
-          });
-        }
+        if (!subscriber)
+          throw new Error(entityNotFoundMessage(Entities.USER, subscriberId));
+
+        if (user.subscribedToUserIds.includes(subscriberId))
+          throw new Error(Errors.ALREADY_SUBSCRIBED);
+        const subscribedToUserIds = [...user.subscribedToUserIds, subscriberId];
+        return await ctx.db.users.change(userId, {
+          subscribedToUserIds,
+        });
       },
     },
     unsubscribeFrom: {
@@ -145,14 +170,18 @@ export const Mutations = new GraphQLObjectType({
       resolve: async (_, args, ctx: Context) => {
         const { userId, unsubId } = args;
         const user = await ctx.userLoader.load(userId);
+        if (!user)
+          throw new Error(entityNotFoundMessage(Entities.USER, userId));
         const unsub = await ctx.userLoader.load(unsubId);
+        if (!unsub)
+          throw new Error(entityNotFoundMessage(Entities.USER, unsubId));
 
-        if (user && unsub && user.subscribedToUserIds.includes(unsubId)) {
-          const subscribedToUserIds = user.subscribedToUserIds.filter(
-            (id) => id !== unsubId
-          );
-          return ctx.db.users.change(userId, { subscribedToUserIds });
-        }
+        if (!user.subscribedToUserIds.includes(unsubId))
+          throw new Error(Errors.NO_SUBSCRIPTION);
+        const subscribedToUserIds = user.subscribedToUserIds.filter(
+          (id) => id !== unsubId
+        );
+        return ctx.db.users.change(userId, { subscribedToUserIds });
       },
     },
   },

--- a/src/routes/graphql/mutation.ts
+++ b/src/routes/graphql/mutation.ts
@@ -19,7 +19,7 @@ export const Mutations = new GraphQLObjectType({
         createUserDTO: { type: CreateUserType },
       },
       async resolve(_, args, ctx: Context) {
-        return ctx.fastify.db.users.create(args.createUserDTO);
+        return ctx.db.users.create(args.createUserDTO);
       },
     },
     createProfile: {
@@ -29,15 +29,15 @@ export const Mutations = new GraphQLObjectType({
       },
       async resolve(_, args, ctx: Context) {
         const user = await ctx.userLoader.load(args.createProfileDTO.userId);
-        if (!user) throw ctx.fastify.httpErrors.badRequest("User not found");
+        if (!user)
+          throw new Error("Bad request, user with this id does not exist");
 
         const memberType = await ctx.memberTypeLoader.load(
           args.createProfileDTO.memberTypeId
         );
-        if (!memberType)
-          throw ctx.fastify.httpErrors.badRequest("Member type not found");
+        if (!memberType) throw new Error("Bad request, invalid member type");
 
-        return ctx.fastify.db.profiles.create(args.createProfileDTO);
+        return ctx.db.profiles.create(args.createProfileDTO);
       },
     },
     createPost: {
@@ -47,9 +47,10 @@ export const Mutations = new GraphQLObjectType({
       },
       async resolve(_, args, ctx: Context) {
         const user = await ctx.userLoader.load(args.createPostDTO.userId);
-        if (!user) throw ctx.fastify.httpErrors.badRequest("User not found");
+        if (!user)
+          throw new Error("Bad request, user with this id does not exist");
 
-        return ctx.fastify.db.posts.create(args.createPostDTO);
+        return ctx.db.posts.create(args.createPostDTO);
       },
     },
     updateMemberType: {
@@ -59,10 +60,13 @@ export const Mutations = new GraphQLObjectType({
         updateMemberTypeDTO: { type: UpdateMemberType },
       },
       async resolve(_, args, ctx: Context) {
-        return ctx.fastify.db.memberTypes.change(
+        const updated = await ctx.db.memberTypes.change(
           args.id,
           args.updateMemberTypeDTO
         );
+        if (!updated) throw new Error("Bad request");
+
+        return updated;
       },
     },
     updatePost: {
@@ -72,7 +76,10 @@ export const Mutations = new GraphQLObjectType({
         updatePostDTO: { type: UpdatePostType },
       },
       async resolve(_, args, ctx: Context) {
-        return ctx.fastify.db.posts.change(args.id, args.updatePostDTO);
+        const updated = await ctx.db.posts.change(args.id, args.updatePostDTO);
+        if (!updated) throw new Error("Bad request");
+
+        return updated;
       },
     },
     updateProfile: {
@@ -82,7 +89,13 @@ export const Mutations = new GraphQLObjectType({
         updateProfileDTO: { type: UpdateProfileType },
       },
       async resolve(_, args, ctx: Context) {
-        return ctx.fastify.db.profiles.change(args.id, args.updateProfileDTO);
+        const updated = await ctx.db.profiles.change(
+          args.id,
+          args.updateProfileDTO
+        );
+        if (!updated) throw new Error("Bad request");
+
+        return updated;
       },
     },
     updateUser: {
@@ -92,7 +105,10 @@ export const Mutations = new GraphQLObjectType({
         updateUserDTO: { type: UpdateUserType },
       },
       async resolve(_, args, ctx: Context) {
-        return ctx.fastify.db.users.change(args.id, args.updateUserDTO);
+        const updated = await ctx.db.users.change(args.id, args.updateUserDTO);
+        if (!updated) throw new Error("Bad request");
+
+        return updated;
       },
     },
     subscribeTo: {
@@ -114,7 +130,7 @@ export const Mutations = new GraphQLObjectType({
             ...user.subscribedToUserIds,
             subscriberId,
           ];
-          return await ctx.fastify.db.users.change(userId, {
+          return await ctx.db.users.change(userId, {
             subscribedToUserIds,
           });
         }
@@ -135,7 +151,7 @@ export const Mutations = new GraphQLObjectType({
           const subscribedToUserIds = user.subscribedToUserIds.filter(
             (id) => id !== unsubId
           );
-          return ctx.fastify.db.users.change(userId, { subscribedToUserIds });
+          return ctx.db.users.change(userId, { subscribedToUserIds });
         }
       },
     },

--- a/src/routes/graphql/mutation.ts
+++ b/src/routes/graphql/mutation.ts
@@ -1,5 +1,6 @@
 import { GraphQLObjectType, GraphQLNonNull, GraphQLString } from "graphql";
 import { Entities, entityNotFoundMessage, Errors } from "./errors";
+import { filterDTO } from "./filterDTO";
 import { Context } from "./types/context";
 import { MemberType, UpdateMemberType } from "./types/memberType";
 import { PostType, CreatePostType, UpdatePostType } from "./types/post";
@@ -75,7 +76,7 @@ export const Mutations = new GraphQLObjectType({
         try {
           const updated = await ctx.db.memberTypes.change(
             args.id,
-            args.updateMemberTypeDTO
+            filterDTO(args.updateMemberTypeDTO)
           );
           return updated;
         } catch {
@@ -91,7 +92,10 @@ export const Mutations = new GraphQLObjectType({
       },
       async resolve(_, args, ctx: Context) {
         try {
-          return await ctx.db.posts.change(args.id, args.updatePostDTO);
+          return await ctx.db.posts.change(
+            args.id,
+            filterDTO(args.updatePostDTO)
+          );
         } catch {
           throw new Error(entityNotFoundMessage(Entities.POST, args.id));
         }
@@ -115,7 +119,10 @@ export const Mutations = new GraphQLObjectType({
         }
 
         try {
-          return await ctx.db.profiles.change(args.id, args.updateProfileDTO);
+          return await ctx.db.profiles.change(
+            args.id,
+            filterDTO(args.updateProfileDTO)
+          );
         } catch {
           throw new Error(entityNotFoundMessage(Entities.PROFILE, args.id));
         }
@@ -129,7 +136,10 @@ export const Mutations = new GraphQLObjectType({
       },
       async resolve(_, args, ctx: Context) {
         try {
-          return await ctx.db.users.change(args.id, args.updateUserDTO);
+          return await ctx.db.users.change(
+            args.id,
+            filterDTO(args.updateUserDTO)
+          );
         } catch {
           throw new Error(entityNotFoundMessage(Entities.USER, args.id));
         }

--- a/src/routes/graphql/mutation.ts
+++ b/src/routes/graphql/mutation.ts
@@ -1,0 +1,143 @@
+import { GraphQLObjectType, GraphQLNonNull, GraphQLString } from "graphql";
+import { Context } from "./types/context";
+import { MemberType, UpdateMemberType } from "./types/memberType";
+import { PostType, CreatePostType, UpdatePostType } from "./types/post";
+import {
+  ProfileType,
+  CreateProfileType,
+  UpdateProfileType,
+} from "./types/profile";
+import { UserType, CreateUserType, UpdateUserType } from "./types/user";
+import { GraphQLUUID } from "./types/uuid";
+
+export const Mutations = new GraphQLObjectType({
+  name: "Mutations",
+  fields: {
+    createUser: {
+      type: UserType,
+      args: {
+        createUserDTO: { type: CreateUserType },
+      },
+      async resolve(_, args, ctx: Context) {
+        return ctx.fastify.db.users.create(args.createUserDTO);
+      },
+    },
+    createProfile: {
+      type: ProfileType,
+      args: {
+        createProfileDTO: { type: CreateProfileType },
+      },
+      async resolve(_, args, ctx: Context) {
+        const user = await ctx.userLoader.load(args.createProfileDTO.userId);
+        if (!user) throw ctx.fastify.httpErrors.badRequest("User not found");
+
+        const memberType = await ctx.memberTypeLoader.load(
+          args.createProfileDTO.memberTypeId
+        );
+        if (!memberType)
+          throw ctx.fastify.httpErrors.badRequest("Member type not found");
+
+        return ctx.fastify.db.profiles.create(args.createProfileDTO);
+      },
+    },
+    createPost: {
+      type: PostType,
+      args: {
+        createPostDTO: { type: CreatePostType },
+      },
+      async resolve(_, args, ctx: Context) {
+        const user = await ctx.userLoader.load(args.createPostDTO.userId);
+        if (!user) throw ctx.fastify.httpErrors.badRequest("User not found");
+
+        return ctx.fastify.db.posts.create(args.createPostDTO);
+      },
+    },
+    updateMemberType: {
+      type: MemberType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+        updateMemberTypeDTO: { type: UpdateMemberType },
+      },
+      async resolve(_, args, ctx: Context) {
+        return ctx.fastify.db.memberTypes.change(
+          args.id,
+          args.updateMemberTypeDTO
+        );
+      },
+    },
+    updatePost: {
+      type: PostType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLUUID) },
+        updatePostDTO: { type: UpdatePostType },
+      },
+      async resolve(_, args, ctx: Context) {
+        return ctx.fastify.db.posts.change(args.id, args.updatePostDTO);
+      },
+    },
+    updateProfile: {
+      type: ProfileType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLUUID) },
+        updateProfileDTO: { type: UpdateProfileType },
+      },
+      async resolve(_, args, ctx: Context) {
+        return ctx.fastify.db.profiles.change(args.id, args.updateProfileDTO);
+      },
+    },
+    updateUser: {
+      type: UserType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLUUID) },
+        updateUserDTO: { type: UpdateUserType },
+      },
+      async resolve(_, args, ctx: Context) {
+        return ctx.fastify.db.users.change(args.id, args.updateUserDTO);
+      },
+    },
+    subscribeTo: {
+      type: UserType,
+      args: {
+        userId: { type: new GraphQLNonNull(GraphQLUUID) },
+        subscriberId: { type: new GraphQLNonNull(GraphQLUUID) },
+      },
+      resolve: async (_, args, ctx: Context) => {
+        const { userId, subscriberId } = args;
+        const user = await ctx.userLoader.load(userId);
+        const subscriber = await ctx.userLoader.load(subscriberId);
+        if (
+          user &&
+          subscriber &&
+          !user.subscribedToUserIds.includes(subscriberId)
+        ) {
+          const subscribedToUserIds = [
+            ...user.subscribedToUserIds,
+            subscriberId,
+          ];
+          return await ctx.fastify.db.users.change(userId, {
+            subscribedToUserIds,
+          });
+        }
+      },
+    },
+    unsubscribeFrom: {
+      type: UserType,
+      args: {
+        userId: { type: new GraphQLNonNull(GraphQLUUID) },
+        unsubId: { type: new GraphQLNonNull(GraphQLUUID) },
+      },
+      resolve: async (_, args, ctx: Context) => {
+        const { userId, unsubId } = args;
+        const user = await ctx.userLoader.load(userId);
+        const unsub = await ctx.userLoader.load(unsubId);
+
+        if (user && unsub && user.subscribedToUserIds.includes(unsubId)) {
+          const subscribedToUserIds = user.subscribedToUserIds.filter(
+            (id) => id !== unsubId
+          );
+          return ctx.fastify.db.users.change(userId, { subscribedToUserIds });
+        }
+      },
+    },
+  },
+});

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -12,8 +12,7 @@ export const RootQuery = new GraphQLObjectType({
     memberTypes: {
       type: new GraphQLList(MemberType),
       resolve: (_obj, _args, ctx: Context) => {
-        console.log(ctx.fastify.db);
-        return ctx.fastify.db.memberTypes.findMany();
+        return ctx.db.memberTypes.findMany();
       },
     },
     memberType: {
@@ -28,7 +27,7 @@ export const RootQuery = new GraphQLObjectType({
     users: {
       type: new GraphQLList(UserType),
       resolve: (_obj, _args, ctx: Context) => {
-        return ctx.fastify.db.users.findMany();
+        return ctx.db.users.findMany();
       },
     },
     user: {
@@ -43,7 +42,7 @@ export const RootQuery = new GraphQLObjectType({
     posts: {
       type: new GraphQLList(PostType),
       resolve: (_obj, _args, ctx: Context) => {
-        return ctx.fastify.db.posts.findMany();
+        return ctx.db.posts.findMany();
       },
     },
     post: {
@@ -58,7 +57,7 @@ export const RootQuery = new GraphQLObjectType({
     profiles: {
       type: new GraphQLList(ProfileType),
       resolve: (_obj, _args, ctx: Context) => {
-        return ctx.fastify.db.profiles.findMany();
+        return ctx.db.profiles.findMany();
       },
     },
     profile: {

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -1,4 +1,5 @@
 import { GraphQLObjectType, GraphQLList, GraphQLString } from "graphql";
+import { Entities, entityNotFoundMessage } from "./errors";
 import { Context } from "./types/context";
 import { MemberType } from "./types/memberType";
 import { PostType } from "./types/post";
@@ -20,8 +21,11 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
       args: {
         id: { type: GraphQLString },
       },
-      resolve: (_obj, args: { id: string }, ctx) => {
-        return ctx.memberTypeLoader.load(args.id);
+      resolve: async (_obj, args: { id: string }, ctx) => {
+        const memberType = await ctx.memberTypeLoader.load(args.id);
+        if (!memberType)
+          throw new Error(entityNotFoundMessage(Entities.MEMBER_TYPE, args.id));
+        return memberType;
       },
     },
     users: {
@@ -35,8 +39,11 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
       args: {
         id: { type: GraphQLUUID },
       },
-      resolve: (_obj, args: { id: string }, ctx) => {
-        return ctx.userLoader.load(args.id);
+      resolve: async (_obj, args: { id: string }, ctx) => {
+        const user = await ctx.userLoader.load(args.id);
+        if (!user)
+          throw new Error(entityNotFoundMessage(Entities.USER, args.id));
+        return user;
       },
     },
     posts: {
@@ -50,8 +57,11 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
       args: {
         id: { type: GraphQLUUID },
       },
-      resolve: (_obj, args: { id: string }, ctx) => {
-        return ctx.postLoader.load(args.id);
+      resolve: async (_obj, args: { id: string }, ctx) => {
+        const post = await ctx.postLoader.load(args.id);
+        if (!post)
+          throw new Error(entityNotFoundMessage(Entities.POST, args.id));
+        return post;
       },
     },
     profiles: {
@@ -65,8 +75,11 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
       args: {
         id: { type: GraphQLUUID },
       },
-      resolve: (_obj, args: { id: string }, ctx) => {
-        return ctx.profileLoader.load(args.id);
+      resolve: async (_obj, args: { id: string }, ctx) => {
+        const profile = await ctx.profileLoader.load(args.id);
+        if (!profile)
+          throw new Error(entityNotFoundMessage(Entities.PROFILE, args.id));
+        return profile;
       },
     },
   },

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -1,0 +1,74 @@
+import { GraphQLObjectType, GraphQLList, GraphQLString } from "graphql";
+import { Context } from "./types/context";
+import { MemberType } from "./types/memberType";
+import { PostType } from "./types/post";
+import { ProfileType } from "./types/profile";
+import { UserType } from "./types/user";
+import { GraphQLUUID } from "./types/uuid";
+
+export const RootQuery = new GraphQLObjectType({
+  name: "RootQueryType",
+  fields: {
+    memberTypes: {
+      type: new GraphQLList(MemberType),
+      resolve: (_obj, _args, ctx: Context) => {
+        console.log(ctx.fastify.db);
+        return ctx.fastify.db.memberTypes.findMany();
+      },
+    },
+    memberType: {
+      type: MemberType,
+      args: {
+        id: { type: GraphQLString },
+      },
+      resolve: (_obj, args, ctx: Context) => {
+        return ctx.memberTypeLoader.load(args.id);
+      },
+    },
+    users: {
+      type: new GraphQLList(UserType),
+      resolve: (_obj, _args, ctx: Context) => {
+        return ctx.fastify.db.users.findMany();
+      },
+    },
+    user: {
+      type: UserType,
+      args: {
+        id: { type: GraphQLUUID },
+      },
+      resolve: (_obj, args, ctx: Context) => {
+        return ctx.userLoader.load(args.id);
+      },
+    },
+    posts: {
+      type: new GraphQLList(PostType),
+      resolve: (_obj, _args, ctx: Context) => {
+        return ctx.fastify.db.posts.findMany();
+      },
+    },
+    post: {
+      type: PostType,
+      args: {
+        id: { type: GraphQLUUID },
+      },
+      resolve: (_obj, args, ctx: Context) => {
+        return ctx.postLoader.load(args.id);
+      },
+    },
+    profiles: {
+      type: new GraphQLList(ProfileType),
+      resolve: (_obj, _args, ctx: Context) => {
+        return ctx.fastify.db.profiles.findMany();
+      },
+    },
+    profile: {
+      type: ProfileType,
+      args: {
+        id: { type: GraphQLUUID },
+      },
+      resolve: (_obj, args, ctx: Context) => {
+        return ctx.profileLoader.load(args.id);
+      },
+    },
+  },
+});

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -6,12 +6,12 @@ import { ProfileType } from "./types/profile";
 import { UserType } from "./types/user";
 import { GraphQLUUID } from "./types/uuid";
 
-export const RootQuery = new GraphQLObjectType({
+export const RootQuery = new GraphQLObjectType<unknown, Context>({
   name: "RootQueryType",
   fields: {
     memberTypes: {
       type: new GraphQLList(MemberType),
-      resolve: (_obj, _args, ctx: Context) => {
+      resolve: (_obj, _args, ctx) => {
         return ctx.db.memberTypes.findMany();
       },
     },
@@ -20,13 +20,13 @@ export const RootQuery = new GraphQLObjectType({
       args: {
         id: { type: GraphQLString },
       },
-      resolve: (_obj, args, ctx: Context) => {
+      resolve: (_obj, args: { id: string }, ctx) => {
         return ctx.memberTypeLoader.load(args.id);
       },
     },
     users: {
       type: new GraphQLList(UserType),
-      resolve: (_obj, _args, ctx: Context) => {
+      resolve: (_obj, _args, ctx) => {
         return ctx.db.users.findMany();
       },
     },
@@ -35,13 +35,13 @@ export const RootQuery = new GraphQLObjectType({
       args: {
         id: { type: GraphQLUUID },
       },
-      resolve: (_obj, args, ctx: Context) => {
+      resolve: (_obj, args: { id: string }, ctx) => {
         return ctx.userLoader.load(args.id);
       },
     },
     posts: {
       type: new GraphQLList(PostType),
-      resolve: (_obj, _args, ctx: Context) => {
+      resolve: (_obj, _args, ctx) => {
         return ctx.db.posts.findMany();
       },
     },
@@ -50,13 +50,13 @@ export const RootQuery = new GraphQLObjectType({
       args: {
         id: { type: GraphQLUUID },
       },
-      resolve: (_obj, args, ctx: Context) => {
+      resolve: (_obj, args: { id: string }, ctx) => {
         return ctx.postLoader.load(args.id);
       },
     },
     profiles: {
       type: new GraphQLList(ProfileType),
-      resolve: (_obj, _args, ctx: Context) => {
+      resolve: (_obj, _args, ctx) => {
         return ctx.db.profiles.findMany();
       },
     },
@@ -65,7 +65,7 @@ export const RootQuery = new GraphQLObjectType({
       args: {
         id: { type: GraphQLUUID },
       },
-      resolve: (_obj, args, ctx: Context) => {
+      resolve: (_obj, args: { id: string }, ctx) => {
         return ctx.profileLoader.load(args.id);
       },
     },

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -12,8 +12,12 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
   fields: {
     memberTypes: {
       type: new GraphQLList(MemberType),
-      resolve: (_obj, _args, ctx) => {
-        return ctx.db.memberTypes.findMany();
+      resolve: async (_obj, _args, ctx) => {
+        const memberTypes = await ctx.db.memberTypes.findMany();
+        memberTypes.forEach((type) =>
+          ctx.memberTypeLoader.prime(type.id, type)
+        );
+        return memberTypes;
       },
     },
     memberType: {
@@ -30,8 +34,16 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
     },
     users: {
       type: new GraphQLList(UserType),
-      resolve: (_obj, _args, ctx) => {
-        return ctx.db.users.findMany();
+      resolve: async (_obj, _args, ctx) => {
+        const users = await ctx.db.users.findMany();
+        users.forEach((user) => {
+          ctx.userLoader.prime(user.id, user);
+          ctx.subscriptionsByUserIdLoader.prime(
+            user.id,
+            users.filter((u) => u.subscribedToUserIds.includes(user.id))
+          );
+        });
+        return users;
       },
     },
     user: {
@@ -48,8 +60,10 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
     },
     posts: {
       type: new GraphQLList(PostType),
-      resolve: (_obj, _args, ctx) => {
-        return ctx.db.posts.findMany();
+      resolve: async (_obj, _args, ctx) => {
+        const posts = await ctx.db.posts.findMany();
+        posts.forEach((post) => ctx.postLoader.prime(post.id, post));
+        return posts;
       },
     },
     post: {
@@ -66,8 +80,12 @@ export const RootQuery = new GraphQLObjectType<unknown, Context>({
     },
     profiles: {
       type: new GraphQLList(ProfileType),
-      resolve: (_obj, _args, ctx) => {
-        return ctx.db.profiles.findMany();
+      resolve: async (_obj, _args, ctx) => {
+        const profiles = await ctx.db.profiles.findMany();
+        profiles.forEach((profile) =>
+          ctx.profileLoader.prime(profile.id, profile)
+        );
+        return profiles;
       },
     },
     profile: {

--- a/src/routes/graphql/types/context.ts
+++ b/src/routes/graphql/types/context.ts
@@ -1,0 +1,6 @@
+import { FastifyInstance } from "fastify/types/instance";
+import { getLoaders } from "../loaders";
+
+export type Context = ReturnType<typeof getLoaders> & {
+  fastify: FastifyInstance;
+};

--- a/src/routes/graphql/types/context.ts
+++ b/src/routes/graphql/types/context.ts
@@ -1,6 +1,6 @@
-import { FastifyInstance } from "fastify/types/instance";
+import DB from "../../../utils/DB/DB";
 import { getLoaders } from "../loaders";
 
 export type Context = ReturnType<typeof getLoaders> & {
-  fastify: FastifyInstance;
+  db: DB;
 };

--- a/src/routes/graphql/types/memberType.ts
+++ b/src/routes/graphql/types/memberType.ts
@@ -6,8 +6,9 @@ import {
   GraphQLInt,
   GraphQLInputObjectType,
 } from "graphql";
+import { MemberTypeEntity } from "../../../utils/DB/entities/DBMemberTypes";
 
-export const MemberType: GraphQLObjectType = new GraphQLObjectType({
+export const MemberType = new GraphQLObjectType<MemberTypeEntity>({
   name: "MemberType",
   fields: () => ({
     id: { type: GraphQLString },

--- a/src/routes/graphql/types/memberType.ts
+++ b/src/routes/graphql/types/memberType.ts
@@ -1,0 +1,26 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLInputObjectType,
+} from "graphql";
+
+export const MemberType: GraphQLObjectType = new GraphQLObjectType({
+  name: "MemberType",
+  fields: () => ({
+    id: { type: GraphQLString },
+    discount: { type: new GraphQLNonNull(GraphQLFloat) },
+    monthPostsLimit: { type: new GraphQLNonNull(GraphQLInt) },
+  }),
+});
+
+export const UpdateMemberType: GraphQLInputObjectType =
+  new GraphQLInputObjectType({
+    name: "UpdateMemberTypeDTO",
+    fields: () => ({
+      discount: { type: GraphQLFloat },
+      monthPostsLimit: { type: GraphQLInt },
+    }),
+  });

--- a/src/routes/graphql/types/post.ts
+++ b/src/routes/graphql/types/post.ts
@@ -9,7 +9,7 @@ import { Context } from "./context";
 import { UserType } from "./user";
 import { GraphQLUUID } from "./uuid";
 
-export const PostType: GraphQLObjectType = new GraphQLObjectType({
+export const PostType = new GraphQLObjectType<PostEntity, Context>({
   name: "Post",
   fields: () => ({
     id: { type: GraphQLUUID },
@@ -17,7 +17,7 @@ export const PostType: GraphQLObjectType = new GraphQLObjectType({
     content: { type: new GraphQLNonNull(GraphQLString) },
     author: {
       type: new GraphQLNonNull(UserType),
-      resolve: (post: PostEntity, _args, ctx: Context) => {
+      resolve: (post, _args, ctx) => {
         return ctx.userLoader.load(post.userId);
       },
     },

--- a/src/routes/graphql/types/post.ts
+++ b/src/routes/graphql/types/post.ts
@@ -1,0 +1,44 @@
+import {
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLInputObjectType,
+} from "graphql";
+import { PostEntity } from "../../../utils/DB/entities/DBPosts";
+import { Context } from "./context";
+import { UserType } from "./user";
+import { GraphQLUUID } from "./uuid";
+
+export const PostType: GraphQLObjectType = new GraphQLObjectType({
+  name: "Post",
+  fields: () => ({
+    id: { type: GraphQLUUID },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type: new GraphQLNonNull(GraphQLString) },
+    author: {
+      type: new GraphQLNonNull(UserType),
+      resolve: (post: PostEntity, _args, ctx: Context) => {
+        return ctx.userLoader.load(post.userId);
+      },
+    },
+  }),
+});
+
+export const CreatePostType: GraphQLInputObjectType =
+  new GraphQLInputObjectType({
+    name: "CreatePostDTO",
+    fields: () => ({
+      title: { type: new GraphQLNonNull(GraphQLString) },
+      content: { type: new GraphQLNonNull(GraphQLString) },
+      userId: { type: new GraphQLNonNull(GraphQLUUID) },
+    }),
+  });
+
+export const UpdatePostType: GraphQLInputObjectType =
+  new GraphQLInputObjectType({
+    name: "UpdatePostDTO",
+    fields: () => ({
+      title: { type: GraphQLString },
+      content: { type: GraphQLString },
+    }),
+  });

--- a/src/routes/graphql/types/post.ts
+++ b/src/routes/graphql/types/post.ts
@@ -15,6 +15,7 @@ export const PostType = new GraphQLObjectType<PostEntity, Context>({
     id: { type: GraphQLUUID },
     title: { type: new GraphQLNonNull(GraphQLString) },
     content: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLUUID) },
     author: {
       type: new GraphQLNonNull(UserType),
       resolve: (post, _args, ctx) => {

--- a/src/routes/graphql/types/profile.ts
+++ b/src/routes/graphql/types/profile.ts
@@ -2,8 +2,8 @@ import {
   GraphQLObjectType,
   GraphQLNonNull,
   GraphQLString,
-  GraphQLInt,
   GraphQLInputObjectType,
+  GraphQLFloat,
 } from "graphql";
 import { ProfileEntity } from "../../../utils/DB/entities/DBProfiles";
 import { Context } from "./context";
@@ -17,10 +17,11 @@ export const ProfileType = new GraphQLObjectType<ProfileEntity, Context>({
     id: { type: GraphQLUUID },
     avatar: { type: new GraphQLNonNull(GraphQLString) },
     sex: { type: new GraphQLNonNull(GraphQLString) },
-    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    birthday: { type: new GraphQLNonNull(GraphQLFloat) },
     country: { type: new GraphQLNonNull(GraphQLString) },
     street: { type: new GraphQLNonNull(GraphQLString) },
     city: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLUUID) },
     user: {
       type: new GraphQLNonNull(UserType),
       resolve: async (profile, _args, ctx) => {
@@ -42,7 +43,7 @@ export const CreateProfileType: GraphQLInputObjectType =
     fields: () => ({
       avatar: { type: new GraphQLNonNull(GraphQLString) },
       sex: { type: new GraphQLNonNull(GraphQLString) },
-      birthday: { type: new GraphQLNonNull(GraphQLInt) },
+      birthday: { type: new GraphQLNonNull(GraphQLFloat) },
       country: { type: new GraphQLNonNull(GraphQLString) },
       street: { type: new GraphQLNonNull(GraphQLString) },
       city: { type: new GraphQLNonNull(GraphQLString) },
@@ -57,7 +58,7 @@ export const UpdateProfileType: GraphQLInputObjectType =
     fields: () => ({
       avatar: { type: GraphQLString },
       sex: { type: GraphQLString },
-      birthday: { type: GraphQLInt },
+      birthday: { type: GraphQLFloat },
       country: { type: GraphQLString },
       street: { type: GraphQLString },
       city: { type: GraphQLString },

--- a/src/routes/graphql/types/profile.ts
+++ b/src/routes/graphql/types/profile.ts
@@ -1,0 +1,62 @@
+import {
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLInputObjectType,
+} from "graphql";
+import { ProfileEntity } from "../../../utils/DB/entities/DBProfiles";
+import { Context } from "./context";
+import { MemberType } from "./memberType";
+import { UserType } from "./user";
+import { GraphQLUUID } from "./uuid";
+
+export const ProfileType: GraphQLObjectType = new GraphQLObjectType({
+  name: "Profile",
+  fields: () => ({
+    id: { type: GraphQLUUID },
+    avatar: { type: new GraphQLNonNull(GraphQLString) },
+    sex: { type: new GraphQLNonNull(GraphQLString) },
+    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    street: { type: new GraphQLNonNull(GraphQLString) },
+    city: { type: new GraphQLNonNull(GraphQLString) },
+    user: { type: new GraphQLNonNull(UserType) },
+    memberType: {
+      type: new GraphQLNonNull(MemberType),
+      resolve: async (profile: ProfileEntity, _args, ctx: Context) => {
+        return ctx.memberTypeLoader.load(profile.memberTypeId);
+      },
+    },
+  }),
+});
+
+export const CreateProfileType: GraphQLInputObjectType =
+  new GraphQLInputObjectType({
+    name: "CreateProfileDTO",
+    fields: () => ({
+      avatar: { type: new GraphQLNonNull(GraphQLString) },
+      sex: { type: new GraphQLNonNull(GraphQLString) },
+      birthday: { type: new GraphQLNonNull(GraphQLInt) },
+      country: { type: new GraphQLNonNull(GraphQLString) },
+      street: { type: new GraphQLNonNull(GraphQLString) },
+      city: { type: new GraphQLNonNull(GraphQLString) },
+      userId: { type: new GraphQLNonNull(GraphQLUUID) },
+      memberTypeId: { type: new GraphQLNonNull(GraphQLString) },
+    }),
+  });
+
+export const UpdateProfileType: GraphQLInputObjectType =
+  new GraphQLInputObjectType({
+    name: "UpdateProfileDTO",
+    fields: () => ({
+      avatar: { type: GraphQLString },
+      sex: { type: GraphQLString },
+      birthday: { type: GraphQLInt },
+      country: { type: GraphQLString },
+      street: { type: GraphQLString },
+      city: { type: GraphQLString },
+      userId: { type: GraphQLUUID },
+      memberTypeId: { type: GraphQLString },
+    }),
+  });

--- a/src/routes/graphql/types/profile.ts
+++ b/src/routes/graphql/types/profile.ts
@@ -11,7 +11,7 @@ import { MemberType } from "./memberType";
 import { UserType } from "./user";
 import { GraphQLUUID } from "./uuid";
 
-export const ProfileType: GraphQLObjectType = new GraphQLObjectType({
+export const ProfileType = new GraphQLObjectType<ProfileEntity, Context>({
   name: "Profile",
   fields: () => ({
     id: { type: GraphQLUUID },
@@ -21,10 +21,15 @@ export const ProfileType: GraphQLObjectType = new GraphQLObjectType({
     country: { type: new GraphQLNonNull(GraphQLString) },
     street: { type: new GraphQLNonNull(GraphQLString) },
     city: { type: new GraphQLNonNull(GraphQLString) },
-    user: { type: new GraphQLNonNull(UserType) },
+    user: {
+      type: new GraphQLNonNull(UserType),
+      resolve: async (profile, _args, ctx) => {
+        return ctx.userLoader.load(profile.userId);
+      },
+    },
     memberType: {
       type: new GraphQLNonNull(MemberType),
-      resolve: async (profile: ProfileEntity, _args, ctx: Context) => {
+      resolve: async (profile, _args, ctx) => {
         return ctx.memberTypeLoader.load(profile.memberTypeId);
       },
     },
@@ -56,7 +61,6 @@ export const UpdateProfileType: GraphQLInputObjectType =
       country: { type: GraphQLString },
       street: { type: GraphQLString },
       city: { type: GraphQLString },
-      userId: { type: GraphQLUUID },
       memberTypeId: { type: GraphQLString },
     }),
   });

--- a/src/routes/graphql/types/user.ts
+++ b/src/routes/graphql/types/user.ts
@@ -27,7 +27,7 @@ export const UserType: GraphQLObjectType = new GraphQLObjectType({
     posts: {
       type: new GraphQLList(PostType),
       resolve: (user: UserEntity, _args, ctx: Context) => {
-        return ctx.fastify.db.posts.findMany({
+        return ctx.db.posts.findMany({
           key: "userId",
           equals: user.id,
         });
@@ -36,7 +36,7 @@ export const UserType: GraphQLObjectType = new GraphQLObjectType({
     userSubscribedTo: {
       type: new GraphQLList(UserType),
       resolve: (user: UserEntity, _args, ctx: Context) => {
-        return ctx.fastify.db.users.findMany({
+        return ctx.db.users.findMany({
           key: "subscribedToUserIds",
           inArray: user.id,
         });
@@ -45,7 +45,7 @@ export const UserType: GraphQLObjectType = new GraphQLObjectType({
     subscribedToUser: {
       type: new GraphQLList(UserType),
       resolve: (user: UserEntity, _args, ctx: Context) => {
-        return ctx.fastify.db.users.findMany({
+        return ctx.db.users.findMany({
           key: "id",
           equalsAnyOf: user.subscribedToUserIds,
         });

--- a/src/routes/graphql/types/user.ts
+++ b/src/routes/graphql/types/user.ts
@@ -1,0 +1,75 @@
+import {
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLList,
+  GraphQLInputObjectType,
+} from "graphql";
+import { UserEntity } from "../../../utils/DB/entities/DBUsers";
+import { Context } from "./context";
+import { PostType } from "./post";
+import { ProfileType } from "./profile";
+import { GraphQLUUID } from "./uuid";
+
+export const UserType: GraphQLObjectType = new GraphQLObjectType({
+  name: "User",
+  fields: () => ({
+    id: { type: GraphQLUUID },
+    firstName: { type: new GraphQLNonNull(GraphQLString) },
+    lastName: { type: new GraphQLNonNull(GraphQLString) },
+    email: { type: new GraphQLNonNull(GraphQLString) },
+    profile: {
+      type: ProfileType,
+      resolve: (user: UserEntity, _args, ctx: Context) => {
+        return ctx.profileByUserIdLoader.load(user.id);
+      },
+    },
+    posts: {
+      type: new GraphQLList(PostType),
+      resolve: (user: UserEntity, _args, ctx: Context) => {
+        return ctx.fastify.db.posts.findMany({
+          key: "userId",
+          equals: user.id,
+        });
+      },
+    },
+    userSubscribedTo: {
+      type: new GraphQLList(UserType),
+      resolve: (user: UserEntity, _args, ctx: Context) => {
+        return ctx.fastify.db.users.findMany({
+          key: "subscribedToUserIds",
+          inArray: user.id,
+        });
+      },
+    },
+    subscribedToUser: {
+      type: new GraphQLList(UserType),
+      resolve: (user: UserEntity, _args, ctx: Context) => {
+        return ctx.fastify.db.users.findMany({
+          key: "id",
+          equalsAnyOf: user.subscribedToUserIds,
+        });
+      },
+    },
+  }),
+});
+
+export const CreateUserType: GraphQLInputObjectType =
+  new GraphQLInputObjectType({
+    name: "CreateUserDTO",
+    fields: () => ({
+      firstName: { type: new GraphQLNonNull(GraphQLString) },
+      lastName: { type: new GraphQLNonNull(GraphQLString) },
+      email: { type: new GraphQLNonNull(GraphQLString) },
+    }),
+  });
+
+export const UpdateUserType: GraphQLInputObjectType =
+  new GraphQLInputObjectType({
+    name: "UpdateUserDTO",
+    fields: () => ({
+      firstName: { type: GraphQLString },
+      lastName: { type: GraphQLString },
+      email: { type: GraphQLString },
+    }),
+  });

--- a/src/routes/graphql/types/user.ts
+++ b/src/routes/graphql/types/user.ts
@@ -19,6 +19,9 @@ export const UserType: GraphQLObjectType<UserEntity, Context> =
       firstName: { type: new GraphQLNonNull(GraphQLString) },
       lastName: { type: new GraphQLNonNull(GraphQLString) },
       email: { type: new GraphQLNonNull(GraphQLString) },
+      subscribedToUserIds: {
+        type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+      },
       profile: {
         type: ProfileType,
         resolve: (user, _args, ctx) => {
@@ -28,20 +31,12 @@ export const UserType: GraphQLObjectType<UserEntity, Context> =
       posts: {
         type: new GraphQLList(PostType),
         resolve: async (user, _args, ctx) => {
-          // return ctx.db.posts.findMany({
-          //   key: "userId",
-          //   equals: user.id,
-          // });
           return await ctx.postsByAuthorIdLoader.load(user.id);
         },
       },
       userSubscribedTo: {
         type: new GraphQLList(UserType),
         resolve: async (user, _args, ctx) => {
-          // return ctx.db.users.findMany({
-          //   key: "subscribedToUserIds",
-          //   inArray: user.id,
-          // });
           return await ctx.subscriptionsByUserIdLoader.load(user.id);
         },
       },

--- a/src/routes/graphql/types/uuid/index.ts
+++ b/src/routes/graphql/types/uuid/index.ts
@@ -1,0 +1,27 @@
+import { GraphQLScalarType } from "graphql";
+import { Kind } from "graphql/language";
+
+import { isUUID } from "./isUUID";
+
+export const GraphQLUUID = new GraphQLScalarType({
+  name: "UUID",
+  serialize: (value) => {
+    if (typeof value !== "string" || !isUUID(value))
+      throw new TypeError(`Invalid UUID`);
+    return value.toLowerCase();
+  },
+  parseValue: (value) => {
+    if (typeof value !== "string" || !isUUID(value))
+      throw new TypeError(`Invalid UUID`);
+    return value.toLowerCase();
+  },
+  parseLiteral: (ast) => {
+    if (ast.kind === Kind.STRING) {
+      if (isUUID(ast.value)) {
+        return ast.value;
+      }
+    }
+
+    return undefined;
+  },
+});

--- a/src/routes/graphql/types/uuid/isUUID.ts
+++ b/src/routes/graphql/types/uuid/isUUID.ts
@@ -1,0 +1,6 @@
+const uuidRegex =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUUID(value: string): boolean {
+  return uuidRegex.test(value);
+}

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -1,34 +1,52 @@
-import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { idParamSchema } from '../../utils/reusedSchemas';
-import { changeMemberTypeBodySchema } from './schema';
-import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
+import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
+import { idParamSchema } from "../../utils/reusedSchemas";
+import { changeMemberTypeBodySchema } from "./schema";
+import type { MemberTypeEntity } from "../../utils/DB/entities/DBMemberTypes";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
+  fastify.get("/", async function (request, reply): Promise<
     MemberTypeEntity[]
-  > {});
+  > {
+    return await fastify.db.memberTypes.findMany();
+  });
 
   fastify.get(
-    '/:id',
+    "/:id",
     {
       schema: {
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const entity = await this.db.memberTypes.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!entity) throw fastify.httpErrors.notFound();
+
+      return entity;
+    }
   );
 
   fastify.patch(
-    '/:id',
+    "/:id",
     {
       schema: {
         body: changeMemberTypeBodySchema,
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      try {
+        return await this.db.memberTypes.change(request.params.id, {
+          ...request.body,
+        });
+      } catch {
+        throw this.httpErrors.badRequest();
+      }
+    }
   );
 };
 

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -1,52 +1,77 @@
-import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { idParamSchema } from '../../utils/reusedSchemas';
-import { createPostBodySchema, changePostBodySchema } from './schema';
-import type { PostEntity } from '../../utils/DB/entities/DBPosts';
+import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
+import { idParamSchema } from "../../utils/reusedSchemas";
+import { createPostBodySchema, changePostBodySchema } from "./schema";
+import type { PostEntity } from "../../utils/DB/entities/DBPosts";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
+  fastify.get("/", async function (request, reply): Promise<PostEntity[]> {
+    return await fastify.db.posts.findMany();
+  });
 
   fastify.get(
-    '/:id',
+    "/:id",
     {
       schema: {
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      const post = await this.db.posts.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!post) throw this.httpErrors.notFound();
+      return post;
+    }
   );
 
   fastify.post(
-    '/',
+    "/",
     {
       schema: {
         body: createPostBodySchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      return await this.db.posts.create({ ...request.body });
+    }
   );
 
   fastify.delete(
-    '/:id',
+    "/:id",
     {
       schema: {
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      try {
+        return await this.db.posts.delete(request.params.id);
+      } catch {
+        throw this.httpErrors.badRequest();
+      }
+    }
   );
 
   fastify.patch(
-    '/:id',
+    "/:id",
     {
       schema: {
         body: changePostBodySchema,
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      try {
+        return await this.db.posts.change(request.params.id, {
+          ...request.body,
+        });
+      } catch {
+        throw this.httpErrors.badRequest();
+      }
+    }
   );
 };
 

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -81,7 +81,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         equals: request.params.id,
       });
       if (!profile) throw this.httpErrors.badRequest();
-      return this.db.profiles.change(request.params.id, { ...request.body });
+      return this.db.profiles.change(request.params.id, request.body);
     }
   );
 };

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -1,54 +1,88 @@
-import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { idParamSchema } from '../../utils/reusedSchemas';
-import { createProfileBodySchema, changeProfileBodySchema } from './schema';
-import type { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
+import { idParamSchema } from "../../utils/reusedSchemas";
+import { createProfileBodySchema, changeProfileBodySchema } from "./schema";
+import type { ProfileEntity } from "../../utils/DB/entities/DBProfiles";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
-    ProfileEntity[]
-  > {});
+  fastify.get("/", async function (request, reply): Promise<ProfileEntity[]> {
+    return await this.db.profiles.findMany();
+  });
 
   fastify.get(
-    '/:id',
+    "/:id",
     {
       schema: {
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const profile = await this.db.profiles.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!profile) throw this.httpErrors.notFound();
+      return profile;
+    }
   );
 
   fastify.post(
-    '/',
+    "/",
     {
       schema: {
         body: createProfileBodySchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const { userId, memberTypeId } = request.body;
+      const user = await this.db.users.findOne({ key: "id", equals: userId });
+      const memberType = await this.db.memberTypes.findOne({
+        key: "id",
+        equals: memberTypeId,
+      });
+      if (!user || !memberType) throw this.httpErrors.badRequest();
+      const profile = await this.db.profiles.findOne({
+        key: "userId",
+        equals: request.body.userId,
+      });
+      if (profile) throw this.httpErrors.badRequest();
+      return await this.db.profiles.create({ ...request.body });
+    }
   );
 
   fastify.delete(
-    '/:id',
+    "/:id",
     {
       schema: {
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      try {
+        return await this.db.profiles.delete(request.params.id);
+      } catch {
+        throw this.httpErrors.badRequest();
+      }
+    }
   );
 
   fastify.patch(
-    '/:id',
+    "/:id",
     {
       schema: {
         body: changeProfileBodySchema,
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const profile = await this.db.profiles.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!profile) throw this.httpErrors.badRequest();
+      return this.db.profiles.change(request.params.id, { ...request.body });
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -1,78 +1,137 @@
-import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { idParamSchema } from '../../utils/reusedSchemas';
+import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
+import { idParamSchema } from "../../utils/reusedSchemas";
 import {
   createUserBodySchema,
   changeUserBodySchema,
   subscribeBodySchema,
-} from './schemas';
-import type { UserEntity } from '../../utils/DB/entities/DBUsers';
+} from "./schemas";
+import type { UserEntity } from "../../utils/DB/entities/DBUsers";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {});
+  fastify.get("/", async function (request, reply): Promise<UserEntity[]> {
+    return await this.db.users.findMany();
+  });
 
   fastify.get(
-    '/:id',
+    "/:id",
     {
       schema: {
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await this.db.users.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!user) throw this.httpErrors.notFound();
+      return user;
+    }
   );
 
   fastify.post(
-    '/',
+    "/",
     {
       schema: {
         body: createUserBodySchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      return await this.db.users.create({ ...request.body });
+    }
   );
 
   fastify.delete(
-    '/:id',
+    "/:id",
     {
       schema: {
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const { id } = request.params;
+      const userToDelete = await this.db.users.findOne({
+        key: "id",
+        equals: id,
+      });
+      if (!userToDelete) throw this.httpErrors.badRequest();
+      const profile = await this.db.profiles.findOne({
+        key: "userId",
+        equals: id,
+      });
+      if (profile) {
+        await this.db.profiles.delete(profile.id);
+      }
+      const posts = await this.db.posts.findMany({ key: "userId", equals: id });
+      posts.forEach((post) => this.db.posts.delete(post.id));
+      return this.db.users.delete(id);
+    }
   );
 
   fastify.post(
-    '/:id/subscribeTo',
+    "/:id/subscribeTo",
     {
       schema: {
         body: subscribeBodySchema,
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await this.db.users.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!user) throw this.httpErrors.notFound();
+      const { subscribedToUserIds } = user;
+      return this.db.users.change(request.params.id, {
+        subscribedToUserIds: [...subscribedToUserIds, request.body.userId],
+      });
+    }
   );
 
   fastify.post(
-    '/:id/unsubscribeFrom',
+    "/:id/unsubscribeFrom",
     {
       schema: {
         body: subscribeBodySchema,
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await this.db.users.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!user) throw this.httpErrors.notFound();
+      let { subscribedToUserIds } = user;
+      const idToUnsubscribe = request.body.userId;
+      if (!subscribedToUserIds.includes(idToUnsubscribe))
+        throw this.httpErrors.badRequest();
+      subscribedToUserIds = subscribedToUserIds.filter(
+        (id) => id !== idToUnsubscribe
+      );
+      return this.db.users.change(request.params.id, { subscribedToUserIds });
+    }
   );
 
   fastify.patch(
-    '/:id',
+    "/:id",
     {
       schema: {
         body: changeUserBodySchema,
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await this.db.users.findOne({
+        key: "id",
+        equals: request.params.id,
+      });
+      if (!user) throw this.httpErrors.badRequest();
+      return await this.db.users.change(request.params.id, { ...request.body });
+    }
   );
 };
 

--- a/src/utils/DB/DB.ts
+++ b/src/utils/DB/DB.ts
@@ -1,8 +1,8 @@
-import DBMemberTypes from './entities/DBMemberTypes';
-import DBPosts from './entities/DBPosts';
-import DBProfiles from './entities/DBProfiles';
-import DBUsers from './entities/DBUsers';
-import * as lodash from 'lodash';
+import DBMemberTypes from "./entities/DBMemberTypes";
+import DBPosts from "./entities/DBPosts";
+import DBProfiles from "./entities/DBProfiles";
+import DBUsers from "./entities/DBUsers";
+import * as lodash from "lodash";
 
 export default class DB {
   users = new DBUsers();
@@ -13,7 +13,8 @@ export default class DB {
   constructor() {
     const deepCopyResultTrap: ProxyHandler<any> = {
       get: (target, prop) => {
-        if (typeof target[prop] === 'function') {
+        console.log("----------------------", prop);
+        if (typeof target[prop] === "function") {
           return (...args: any[]) => {
             const result = target[prop](...args);
             if (result instanceof Promise) {


### PR DESCRIPTION
Task: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md
Done 2023-01-31 / deadline 2023-01-31
Score: 360 / 360

### Basic Scope
- [x] **+72** Task 1: restful endpoints.
- [x] **+72** Subtasks 2.1-2.7: get gql queries.
- [x] **+54** Subtasks 2.8-2.11: create gql queries.
- [x] **+54** Subtasks 2.12-2.17: update gql queries.
- [x] **+88** Task 3: solve `n+1` graphql problem.
- [x] **+20** Task 4: limit the complexity of the graphql queries.

### Forfeits
- [ ] **-30% of max task score** Commits after deadline (except commits that affect only Readme.md, .gitignore, etc.)
- [ ] **-60% of max task score** Samples of POST body for gql requests were not provided for those subtasks that were declared to be completed.
- [ ] **-100% of max task score** Tests have been modified.
- [ ] **-20** No separate development branch
- [ ] **-20** No Pull Request
- [ ] **-10** Pull Request description is incorrect
- [ ] **-20** Less than 3 commits in the development branch, not including commits that make changes only to `Readme.md` or similar files (`tsconfig.json`, `.gitignore`, `.prettierrc.json`, etc.)
---
## Readme
### Installation
1. Clone this repo `https://github.com/py-cs/node-graphql.git`
2. Install dependencies `npm i`
3. Checkout to develop branch `git checkout develop`

### How to check tasks
1. Add logic to the restful endpoints.  
   1.1. `npm run test` - 100% tests pass
   1.2. `node check-integrity.js` - no changes in tests and db
---
2. Add logic to the graphql endpoint.
> For testing purposes seeding plugin included in repo. Server will start with prefilled entities. To remove this feature delete plugin `src/plugins/seed.ts`. Number of entities and subscription dependencies can be configured via config variable in `src/plugins/seed.ts` file:
```
const config = {
  users: 10, // Number of users with profiles to create
  maxPostsPerUser: 6, // Max number of posts for each user (random value from 1 to this limit)
  subscriptions: 30, // Total number of random subscriptions
};
```
> Postman collection `gql.postman_collection.json` included in repo. Collection includes all queries listed bellow. Import collection to your postman client to use it.

**Get gql requests:**  
2.1. Get users, profiles, posts, memberTypes - 4 operations in one query.
    Query example:
    
    ```
    query allEntities {
        memberTypes {
            id
            discount
            monthPostsLimit
        }
        posts {
            id
            title
            content
        }
        users {
            id
            email
            firstName
            lastName
            subscribedToUserIds
        }
        profiles {
            id
            avatar
            birthday
            sex
            country
            city
            street
        }
    }
    ```
   2.2. Get user, profile, post, memberType by id - 4 operations in one query.
   > **Constraints and validations:** user, profile and post IDs should be valid UUID. Member type ID is a string. If entity is not found corresponding error will be included in responce.
   
   Query example:
   ```
    query entitiesByIds ($userId: UUID!, $profileId: UUID!, $memberTypeId: String!, $postId: UUID!) {
        user(id: $userId) {
            id
            firstName
            lastName
            email
        }
        profile(id: $profileId) {
            id
            avatar
            birthday
            sex
            country
            city
            street
        }
        memberType(id: $memberTypeId) {
            id
            discount
            monthPostsLimit
        }
        post(id: $postId) {
            id
            title
            content
        }
    }
   ```
   Variables:
   ```
   {
        "userId": "",
        "profileId": "",
        "memberTypeId": "basic",
        "postId": ""
    }
   ```
   2.3. Get users with their posts, profiles, memberTypes.
   Query example:
   ```
    query allUsers {
        users {
            id
            firstName
            lastName
            email
            profile {
                id
                avatar
                birthday
                sex
                country
                city
                street
                memberType {
                    id
                    discount
                    monthPostsLimit
                }
            }
            posts {
                id
                title
                content
            }
        }
    }
   ```
   2.4. Get user by id with his posts, profile, memberType.
   > **Constraints and validations:** user ID should be valid UUID. If user is not found corresponding error will be included in responce.

   Query example:
   ```
   query userById ($userId: UUID!) {
        user(id: $userId) {
            id
            firstName
            lastName
            email
            profile {
                id
                avatar
                birthday
                sex
                country
                city
                street
                memberType {
                    id
                    discount
                    monthPostsLimit
                }
            }
            posts {
                id
                title
                content
            }
    
        }
    }
   ```
   Variables:
   ```
   {
        "userId": ""
    }
   ```
   2.5. Get users with their `userSubscribedTo`, profile.
   Query example:
   ```
    query usersWithSubscriptions {
        users {
            id
            firstName
            lastName
            profile {
                id
                avatar
                birthday
                sex
                country
                city
                street
            }
            userSubscribedTo {
                id
                firstName
                lastName
            }
        }
    }
   ```
   2.6. Get user by id with his `subscribedToUser`, posts.
   
> **Constraints and validations:** user ID should be valid UUID. If user is not found corresponding error will be included in responce.
    
   Query example:
   ```
   query userByIdWithFollowersAndPosts ($userId: UUID!) {
        user(id: $userId) {
            id
            firstName
            lastName
            subscribedToUser {
                id
                firstName
                lastName
            }
            posts {
                id
                title
                content
            }
        }
    }
   ```
   Variables:
   ```
   {
        "userId": ""
    }
   ```
   2.7. Get users with their `userSubscribedTo`, `subscribedToUser` (additionally for each user in `userSubscribedTo`, `subscribedToUser` add their `userSubscribedTo`, `subscribedToUser`).  
   Query example:
   ```
   query usersWithSubscriptionsAndFollowers {
        users {
            id
            firstName
            userSubscribedTo {
                id
                firstName
                userSubscribedTo {
                    id
                    firstName
                }
                subscribedToUser {
                    id
                    firstName
                }
            }
            subscribedToUser {
                id
                firstName
                userSubscribedTo {
                    id
                    firstName
                }
                subscribedToUser {
                    id
                    firstName
                }
            }
        }
    }
   ```
   ---
   **Create gql requests:***
   2.8. Create user.
> **Constraints and validations:** all fields in input type are required and validated against their types.
  
   Query example:
   ```
   mutation createUser($createUserDTO: CreateUserDTO!) {
        createUser(createUserDTO: $createUserDTO) {
            id
            firstName
            lastName,
            email
        }
    }
   ```
   Variables:
   ```
    {
        "createUserDTO": {
            "firstName": "first",
            "lastName": "last",
            "email": "mail@mail.com"
        }
    }
   ```
   2.9. Create profile.
> **Constraints and validations:** all fields in input type are required and validated against their types. If user with provided userId or memberType with provided memberTypeId is not found, profile will not be created, corresponding error message will be included in responce.
    
   Query example:
   ```
   mutation createProfile($createProfileDTO: CreateProfileDTO!) {
        createProfile(createProfileDTO: $createProfileDTO) {
            id
            avatar
            birthday
            sex
            country
            city
            street
        }
    }
   ```
   Variables:
   ```
   {
        "createProfileDTO": {
            "city": "City",
            "avatar": "avatar",
            "street": "street",
            "sex": "yes, please",
            "country": "nz",
            "birthday": 100,
            "memberTypeId": "basic",
            "userId": ""
        }
    }
   ```
   2.10. Create post.
 > **Constraints and validations:** all fields in input type are required and validated against their types. If user with provided userId is not found, post will not be created, corresponding error message will be included in responce.
   
   Query example:
   ```
   mutation createPost($createPostDTO: CreatePostDTO!) {
        createPost(createPostDTO: $createPostDTO) {
            id
            title
            content
        }
    }
   ```
   Variables:
   ```
   {
        "createPostDTO": {
            "title": "title",
            "content": "content",
            "userId": ""
        }
    }
   ```
   2.11. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.

- [CreateUserDTO](https://vscode.dev/github.com/py-cs/node-graphql/blob/f0372fa6fcd927e5a311a4eed226056ae2cba5ab/src/routes/graphql/types/user.ts#L52-L53)
- [CreatePostDTO](https://vscode.dev/github.com/py-cs/node-graphql/blob/f0372fa6fcd927e5a311a4eed226056ae2cba5ab/src/routes/graphql/types/post.ts#L28)
- [CreateProfileDTO](https://vscode.dev/github.com/py-cs/node-graphql/blob/f0372fa6fcd927e5a311a4eed226056ae2cba5ab/src/routes/graphql/types/profile.ts#L40)
---
   **Update gql requests:**
   2.12. Update user.
 > **Constraints and validations:** userId is required and validated as UUID. All fields in input type are optional and validated against their types if provided. If user with provided userId is not found, corresponding error message will be included in responce.
   
   Query example:
   ```
   mutation updateUser($userId: UUID!, $updateUserDTO: UpdateUserDTO!) {
        updateUser(
            id: $userId,
            updateUserDTO: $updateUserDTO
            )
        {
            id
            firstName
            lastName
            email
        }
    }
   ```
   Variables:
   ```
   {
        "userId": "",
        "updateUserDTO": {
            "firstName": "updated",
            "lastName": "updated",
            "email": "updated@mail.com"
        }
    }
   ```
   2.13. Update profile.
 > **Constraints and validations:** profileId is required and validated as UUID. All fields in input type are optional and validated against their types if provided. If profile with provided profileId is not found, corresponding error message will be included in responce. In addition if memberTypeId is not found request will result in error.
     
   Query example:
   ```
   mutation updateProfile($profileID: UUID!, $updateProfileDTO: UpdateProfileDTO!) {
        updateProfile(
            id: $profileID,
            updateProfileDTO: $updateProfileDTO
            )
        {
            id
            avatar
            birthday
            sex
            country
            city
            street
        }
    }
   ```
   Variables:
   ```
   {
    "profileID": "5cd302e2-c525-4142-9bc8-da0412480998",
        "updateProfileDTO": {
            "avatar": "no avatar",
            "birthday": 10000,
            "sex": "male",
            "country": "nz",
            "city": "updated",
            "street": "street",
            "memberTypeId": "business"
        }
    }
   ```
   2.14. Update post.
 > **Constraints and validations:** postId is required and validated as UUID. All fields in input type are optional and validated against their types if provided. If post with provided postId is not found, corresponding error message will be included in responce.
     
   Query example:
   ```
   mutation updatePost($postId: UUID!, $updatePostDTO: UpdatePostDTO!) {
        updatePost(
            id: $postId,
            updatePostDTO: $updatePostDTO
            )
        {
            id
            title
            content
        }
    }
   ```
   Variables:
   ```
   {
        "postId": "14e280c7-ecf0-4ba1-ac38-7a8ce97d53e6",
        "updatePostDTO": {
            "title": "updated",
            "content": "updated"
        }
    }
   ```
   2.15. Update memberType.
 > **Constraints and validations:** memberTypeId is required and validated as string. All fields in input type are optional and validated against their types if provided. If memberType with provided memberTypeId is not found, corresponding error message will be included in responce.
     
   Query example:
   ```
   mutation updateMemberType($memberTypeId: String!, $updateMemberTypeDTO: UpdateMemberTypeDTO!) {
        updateMemberType(
            id: $memberTypeId,
            updateMemberTypeDTO: $updateMemberTypeDTO
            )
        {
            id
            discount
            monthPostsLimit
        }
    }
   ```
   Variables:
   ```
   {
        "memberTypeId": "basic",
        "updateMemberTypeDTO": {
            "discount": 10,
            "monthPostsLimit": 0
        }
    }
   ```
   2.16a. Subscribe to.
 > **Constraints and validations:** userId and subscriberId are required and validated as UUID. User and subscriber should exist, user and subscriber should be distinct entities (should have different ids), subscriber shouldn't be already subscribed to user. If any of these checks will fail request will result in error.
     
   Query example:
   ```
   mutation subscribeToUser($userId: UUID!, $subscriberId: UUID!) {
        subscribeTo(
            userId: $userId,
            subscriberId: $subscriberId
            )
        {
            id
            firstName
            lastName
            subscribedToUser {
                id
                firstName
                lastName
            }
        }
    }
   ```
   Variables:
   ```
   {
        "userId": "",
        "subscriberId": ""
    }
   ```
   2.16b. Unsubscribe from.
 > **Constraints and validations:** userId and unsubId are required and validated as UUID. User and unsubscriber should exist, user and unsubscriber should be distinct entities (should have different ids), unsubscriber should be subscribed to user. If any of these checks will fail request will result in error.
     
   Query example:
   ```
   mutation unsubscribeFromUser($userId: UUID!, $unsubId: UUID!) {
        unsubscribeFrom(
            userId: $userId,
            unsubId: $unsubId
            )
        {
            id
            firstName
            lastName
            subscribedToUser {
                id
                firstName
                lastName
            }
        }
    }
   ```
   Variables:
   ```
   {
        "userId": "",
        "unsubId": ""
    }
   ```
   2.17. [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.

- [UpdateMemberTypeDTO](https://vscode.dev/github.com/py-cs/node-graphql/blob/f0372fa6fcd927e5a311a4eed226056ae2cba5ab/src/routes/graphql/types/memberType.ts#L20)
- [UpdateUserDTO](https://vscode.dev/github.com/py-cs/node-graphql/blob/f0372fa6fcd927e5a311a4eed226056ae2cba5ab/src/routes/graphql/types/user.ts#L62)
- [UpdatePostDTO](https://vscode.dev/github.com/py-cs/node-graphql/blob/f0372fa6fcd927e5a311a4eed226056ae2cba5ab/src/routes/graphql/types/post.ts#L38)
- [UpdateProfileDTO](https://vscode.dev/github.com/py-cs/node-graphql/blob/f0372fa6fcd927e5a311a4eed226056ae2cba5ab/src/routes/graphql/types/profile.ts#L55)
---
3. Solve `n+1` graphql problem with dataloader package
> To check dataloader effect you can add console message in db code that will fire every time when access to db is occured: `src\utils\DB\DB.ts` Number of db calls will not change when request complexity (nesting) or entities number increases.
```
import DBMemberTypes from "./entities/DBMemberTypes";
import DBPosts from "./entities/DBPosts";
import DBProfiles from "./entities/DBProfiles";
import DBUsers from "./entities/DBUsers";
import * as lodash from "lodash";

export default class DB {
  users = new DBUsers();
  profiles = new DBProfiles();
  memberTypes = new DBMemberTypes();
  posts = new DBPosts();

  constructor() {
    const deepCopyResultTrap: ProxyHandler<any> = {
      get: (target, prop) => {
        console.log("-------------------------------- DB accessed:", prop);
        if (typeof target[prop] === "function") {
          return (...args: any[]) => {
            const result = target[prop](...args);
            if (result instanceof Promise) {
              return result.then((v) => lodash.cloneDeep(v));
            }
            return lodash.cloneDeep(result);
          };
        } else {
          return target[prop];
        }
      },
    };
    for (const [k, v] of Object.entries(this)) {
      this[k as keyof typeof this] = new Proxy(v, deepCopyResultTrap);
    }
  }
}

```
   3.1. List where the dataloader was used with links to the lines of code
   - Dataloaders are created in `src\routes\graphql\loaders.ts` [link](https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/loaders.ts#L1)
   - Loaders are used:
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L35
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L39
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L44
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L62
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L113
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L158
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L162
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L182
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/mutation.ts#L185
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/query.ts#L29
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/query.ts#L55
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/query.ts#L75
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/query.ts#L97
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/types/post.ts#L22
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/types/profile.ts#L28
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/types/profile.ts#L34
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/types/user.ts#L28
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/types/user.ts#L34
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/types/user.ts#L40
        * https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/types/user.ts#L46
---
4. Limit the complexity of the graphql queries by their depth with graphql-depth-limit package.  
   4.1. Link to the line of code where it was used:
    - [Depht limit value](https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/index.ts#L19)
    - [Depth limit validation](https://vscode.dev/github.com/py-cs/node-graphql/blob/02da8b3b03fa0534510004f6a3124cc94d90bb90/src/routes/graphql/index.ts#L37)
   4.2. Example of query exceeding complexity limit:
    > Example request has 7 levels of nesting and should fail with corresponding error message. If at least one level of complexity is removed request will be executed successfully.
    
    ```
    query nestedPosts {
        posts {
            id
            author {
                id
                posts {
                    author {
                        id
                        posts {
                            id
                            author {
                                id
                                posts {
                                    id
                                }
                            }
                        }
                    }
                }
            }
        }
    }
    ```